### PR TITLE
Prepare for automatic publishing to `@pulsar-edit/git-utils` on NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 16
     - name: Install
       run: |
         npm run prepare

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm run prepare
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm run prepare
+      - run: npm ci
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 env:
   NODE_VERSION: 16
   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+  CC: clang
+  CXX: clang++
+  npm_config_clang: 1
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.log
 *~
 .node-version
+.cache
+.tool-versions
+compile_commands.json

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,15 +5,17 @@
       'dependencies': [
         'libgit2'
       ],
-      'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
+      'include_dirs': ['<!(node -e "require(\'nan\')")'],
       'sources': [
         'src/repository.cc'
       ],
       'conditions': [
         ['OS=="win"', {
           'msvs_disabled_warnings': [
-            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of data
-            4530,  # C++ exception handler used, but unwind semantics are not enabled.
+            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of
+                   # data
+            4530,  # C++ exception handler used, but unwind semantics are not
+                   # enabled.
             4506,  # no definition for inline function
             4267,  # conversion from 'size_t' to 'int', possible loss of data
             4344,  # behavior change
@@ -23,7 +25,8 @@
             '-Wno-missing-field-initializers',
           ],
           'cflags_cc!': [
-            '-fno-delete-null-pointer-checks', # clang-3.4 doesn't understand this flag and fails.
+            '-fno-delete-null-pointer-checks',  # clang-3.4 doesn't understand
+                                                # this flag and fails.
           ],
           'xcode_settings': {
             'WARNING_CFLAGS': [
@@ -374,11 +377,14 @@
           },
           'msvs_disabled_warnings': [
             4005,  # macro redefinition
-            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of data
+            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of
+                   # data
             4267,  # conversion from 'size_t' to 'int', possible loss of data
             4090,  # different 'volatile' qualifiers
-            4047,  # 'volatile void *' differs in levels of indirection from 'int'
-            4013,  # 'InterlockedDecrement' undefined; assuming extern returning int
+            4047,  # 'volatile void *' differs in levels of indirection from
+                   # 'int'
+            4013,  # 'InterlockedDecrement' undefined; assuming extern
+                   # returning int
           ],
           'sources': [
             'deps/libgit2/src/net.c',
@@ -513,7 +519,8 @@
       'conditions': [
         ['OS=="win"', {
           'msvs_disabled_warnings': [
-            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of data
+            4244,  # conversion from 'ssize_t' to 'int32_t', possible loss of
+                   # data
           ],
         }],
       ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "git-utils",
+  "name": "@pulsar-edit/git-utils",
   "description": "A package for using Git repositories",
   "version": "5.7.3",
   "license": "MIT",

--- a/spec/git-spec.js
+++ b/spec/git-spec.js
@@ -1059,36 +1059,51 @@ describe('git', () => {
     })
   })
 
-  describe('.submoduleForPath(path)', () => {
-    beforeEach(() => {
-      const repoDirectory = temp.mkdirSync('node-git-repo-')
-      const submoduleDirectory = temp.mkdirSync('node-git-repo-')
-      wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'master.git'), path.join(repoDirectory, '.git'))
-      wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'master.git'), path.join(submoduleDirectory, '.git'))
+  if (process.env.CI) {
+    // NOTE: Testing a submodule requires that you be able to add one defined
+    // at a path on disk. This is disallowed by default these days as a
+    // security risk. There's a config setting to allow it, but we don't seem
+    // to be able to opt into it on a per-repo basis.
+    //
+    // So this test is disabled unless we're running in CI, where the
+    // environment is transient and will be thrown away anyway. If you want to
+    // test this locally, save your config value for `protocol.file.allow`
+    // beforehand and restore it when you're done testing.
+    describe('.submoduleForPath(path)', () => {
+      beforeEach(() => {
+        const repoDirectory = temp.mkdirSync('node-git-repo-')
+        const submoduleDirectory = temp.mkdirSync('node-git-repo-')
+        wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'master.git'), path.join(repoDirectory, '.git'))
+        wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures', 'master.git'), path.join(submoduleDirectory, '.git'))
 
-      const gitCommandHandler = jasmine.createSpy('gitCommandHandler')
-      execCommands([`cd ${repoDirectory}`, `git submodule add ${submoduleDirectory} sub`], gitCommandHandler)
+        const gitCommandHandler = jasmine.createSpy('gitCommandHandler')
+        execCommands([
+          `git config --global protocol.file.allow always`,
+          `cd ${repoDirectory}`,
+          `git submodule add ${submoduleDirectory} sub`
+        ], gitCommandHandler)
 
-      waitsFor(() => gitCommandHandler.callCount === 1)
+        waitsFor(() => gitCommandHandler.callCount === 1)
 
-      runs(() => repo = git.open(repoDirectory))
+        runs(() => repo = git.open(repoDirectory))
+      })
+
+      it('returns the repository for the path', () => {
+        expect(repo.submoduleForPath()).toBe(null)
+        expect(repo.submoduleForPath(null)).toBe(null)
+        expect(repo.submoduleForPath('')).toBe(null)
+        expect(repo.submoduleForPath('sub1')).toBe(null)
+
+        let submoduleRepoPath = path.join(repo.getPath(), 'modules', 'sub/')
+        if (process.platform === 'win32') { submoduleRepoPath = submoduleRepoPath.replace(/\\/g, '/') }
+
+        expect(repo.submoduleForPath('sub').getPath()).toBe(submoduleRepoPath)
+        expect(repo.submoduleForPath('sub/').getPath()).toBe(submoduleRepoPath)
+        expect(repo.submoduleForPath('sub/a').getPath()).toBe(submoduleRepoPath)
+        expect(repo.submoduleForPath('sub/a/b/c/d').getPath()).toBe(submoduleRepoPath)
+      })
     })
-
-    it('returns the repository for the path', () => {
-      expect(repo.submoduleForPath()).toBe(null)
-      expect(repo.submoduleForPath(null)).toBe(null)
-      expect(repo.submoduleForPath('')).toBe(null)
-      expect(repo.submoduleForPath('sub1')).toBe(null)
-
-      let submoduleRepoPath = path.join(repo.getPath(), 'modules', 'sub/')
-      if (process.platform === 'win32') { submoduleRepoPath = submoduleRepoPath.replace(/\\/g, '/') }
-
-      expect(repo.submoduleForPath('sub').getPath()).toBe(submoduleRepoPath)
-      expect(repo.submoduleForPath('sub/').getPath()).toBe(submoduleRepoPath)
-      expect(repo.submoduleForPath('sub/a').getPath()).toBe(submoduleRepoPath)
-      expect(repo.submoduleForPath('sub/a/b/c/d').getPath()).toBe(submoduleRepoPath)
-    })
-  })
+  }
 
   describe('.add(path)', () => {
     beforeEach(() => {


### PR DESCRIPTION
OK, this applies the workflow that worked for `less-cache` to `git-utils`. The steps as described in the workflow seem to work for me locally.

While I was here, I added some stuff to `.gitignore` and cleaned up the `binding.gyp` so that the Python LSP doesn't complain about some stylistic things.